### PR TITLE
device: update console trait

### DIFF
--- a/src/board/qemu/aarch64/debug.rs
+++ b/src/board/qemu/aarch64/debug.rs
@@ -1,23 +1,22 @@
 use crate::device;
-use core::fmt;
+
 struct QemuDebugCon;
 
-impl device::console::ConsoleOut for QemuDebugCon {
-    fn write_str(&mut self, s: &str) -> fmt::Result {
+impl device::console::Console for QemuDebugCon {
+    fn putc(&self, c: char) -> Result<(), &'static str> {
         unsafe {
-            core::ptr::write_volatile(0x0900_002c as *mut u32, 1 << 4);
-            core::ptr::write_volatile(0x0900_0030 as *mut u32, 0x301);
-        }
-        for c in s.chars() {
-            unsafe {
-                core::ptr::write_volatile(0x0900_0000 as *mut u32, c as u32);
-            }
+            core::ptr::write_volatile(0x0900_0000 as *mut u32, c as u32);
         }
         Ok(())
+    }
+
+    fn getc(&self) -> Result<char, &'static str> {
+        let c = unsafe { core::ptr::read_volatile(0x0900_0000 as *mut u32) as u8 };
+        Ok(c as char)
     }
 }
 
 /// return simple consout out object
-pub fn console() -> impl device::console::ConsoleOut {
+pub fn console() -> impl device::console::Console {
     QemuDebugCon {}
 }

--- a/src/board/raspberrypi/pico/debug.rs
+++ b/src/board/raspberrypi/pico/debug.rs
@@ -1,20 +1,26 @@
 use crate::device;
-use core::fmt;
-struct QemuDebugCon;
 
-impl device::console::ConsoleOut for QemuDebugCon {
-    fn write_str(&mut self, s: &str) -> fmt::Result {
-        for c in s.chars() {
-            unsafe {
-                while (core::ptr::read_volatile(0x4003_4018 as *mut u32) & (1 << 5)) != 0 {}
-                core::ptr::write_volatile(0x4003_4000 as *mut u32, c as u32);
-            }
+struct DebugCon;
+
+impl device::console::Console for DebugCon {
+    fn putc(&self, c: char) -> Result<(), &'static str> {
+        unsafe {
+            while (core::ptr::read_volatile(0x4003_4018 as *mut u32) & (1 << 5)) != 0 {}
+            core::ptr::write_volatile(0x4003_4000 as *mut u32, c as u32);
         }
         Ok(())
+    }
+
+    fn getc(&self) -> Result<char, &'static str> {
+        let c = unsafe {
+            while (core::ptr::read_volatile(0x4003_4018 as *mut u32) & (1 << 4)) != 0 {}
+            core::ptr::read_volatile(0x4003_4000 as *mut u32) as u8
+        };
+        Ok(c as char)
     }
 }
 
 /// return simple consout out object
-pub fn console() -> impl device::console::ConsoleOut {
-    QemuDebugCon {}
+pub fn console() -> impl device::console::Console {
+    DebugCon {}
 }

--- a/src/device/console.rs
+++ b/src/device/console.rs
@@ -1,1 +1,8 @@
-pub use core::fmt::Write as ConsoleOut;
+/// trait for a Console device
+pub trait Console {
+    /// send a char to the console
+    fn putc(&self, c: char) -> Result<(), &'static str>;
+
+    /// get a char from the console
+    fn getc(&self) -> Result<char, &'static str>;
+}

--- a/src/lib/print.rs
+++ b/src/lib/print.rs
@@ -1,11 +1,24 @@
 use crate::{board, device};
 use core::fmt;
+use core::fmt::Write;
+use device::console::Console;
+
+struct ConsolePrinter;
+
+impl core::fmt::Write for ConsolePrinter {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        let console = board::debug::console();
+        for c in s.chars() {
+            console.putc(c).map_err(|_| fmt::Error {})?;
+        }
+        Ok(())
+    }
+}
 
 #[doc(hidden)]
 pub fn _print(args: fmt::Arguments) {
-    use device::console::ConsoleOut;
-
-    board::debug::console().write_fmt(args).unwrap();
+    let mut con = ConsolePrinter {};
+    con.write_fmt(args).unwrap();
 }
 
 /// Prints without a newline.


### PR DESCRIPTION
Create simple Console Trait. Also move core::fmt::Write trait
implementation to print library. So, it is not needed for each debug
module to implement that trait

Signed-off-by: Fernando Lugo <lugo.fernando@gmail.com>