### PR TITLE
armv6m: add dummy __aeabi_unwind_cpp_pr0

### DIFF
--- a/src/_arch/armv6m/cpu.rs
+++ b/src/_arch/armv6m/cpu.rs
@@ -59,3 +59,6 @@ fn _start() -> ! {
     use crate::rrt;
     rrt::init();
 }
+
+#[no_mangle]
+fn __aeabi_unwind_cpp_pr0() {}


### PR DESCRIPTION
It is needed in order to compile in debug build

Signed-off-by: Fernando Lugo <lugo.fernando@gmail.com>